### PR TITLE
Update dependencies and Django version to 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BeDjango starter skeleton ![](http://www.bedjango.com/static/images/logo-bedjango.svg)
 
-An easy to use project template for Django 1.10, for more information visit our [blog](http://www.bedjango.com/blog/create-django-application-bedjango-starter/)
+An easy to use project template for Django 1.11, for more information visit our [blog](http://www.bedjango.com/blog/create-django-application-bedjango-starter/)
 
 [![Build Status](https://api.travis-ci.org/BeDjango/bedjango-starter.svg?branch=master)](https://travis-ci.org/BeDjango/bedjango-starter)
 [![Coverage Status](https://coveralls.io/repos/github/BeDjango/bedjango-starter/badge.svg)](https://coveralls.io/github/BeDjango/bedjango-starter)
@@ -54,7 +54,7 @@ virtualenv -p python3 venv
 
 # Activate virtualenv and install Django
 source venv/bin/activate
-pip install django==1.10
+pip install django==1.11
 
 Use django-admin to create the app using the starter
 django-admin.py startproject --template=https://github.com/BeDjango/bedjango-starter/archive/master.zip --extension=py,rst,yml <b>{{nameofproject}}</b>

--- a/project_name/requirements.txt
+++ b/project_name/requirements.txt
@@ -1,9 +1,9 @@
-Django==1.10
-django-registration==2.1.2
-django-countries==4.0
-django-debug-toolbar==1.6
-django-material==0.12.5
-django-cachalot==1.4.1
+Django==1.11
+django-registration==2.3
+django-countries==5.0
+django-debug-toolbar==1.8
+django-material==1
+django-cachalot==1.5.0
 python-memcached==1.58
 django-rosetta==0.7.13
 django-cookie-law==1.0.13


### PR DESCRIPTION
This starter is currently written for 1.10, so I decided to go ahead and update it to 1.11 since 1.10 will soon be un-supported throughout many 3rd party libraries when Django 2.0 is released.

The different dependency version bumps I also added were for more stable versions of the package. The actual updates don't seem to interfere with the code that's already written.

Anyways, I ran the the tests and build seems to be working fine. I also went and tested out the different features on the actual web-app. 